### PR TITLE
fix dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "0.1.0",
       "dependencies": {
         "@types/node": "22.13.14",
-        "@types/react": "18.3.12",
+        "@types/react": "19.1.0",
         "@types/react-dom": "19.0.4",
         "autoprefixer": "10.4.21",
         "eslint": "9.23.0",
         "eslint-config-next": "15.2.4",
         "next": "15.2.4",
         "postcss": "8.5.3",
-        "react": "18.3.1",
+        "react": "19.1.0",
         "react-dom": "19.1.0",
         "tailwindcss": "3.4.17",
         "typescript": "5.8.2"
@@ -871,17 +871,12 @@
         "undici-types": "~6.20.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.5",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
-    },
     "node_modules/@types/react": {
-      "version": "18.3.12",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.12.tgz",
-      "integrity": "sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-UaicktuQI+9UKyA4njtDOGBD/67t8YEBt2xdfqu8+gP9hqPUPsiXlNPcpS2gVdjmis5GKPG3fCxbQLVgxsQZ8w==",
+      "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.0.2"
       }
     },
@@ -4362,12 +4357,10 @@
       ]
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -10,14 +10,14 @@
   },
   "dependencies": {
     "@types/node": "22.13.14",
-    "@types/react": "18.3.12",
+    "@types/react": "19.1.0",
     "@types/react-dom": "19.0.4",
     "autoprefixer": "10.4.21",
     "eslint": "9.23.0",
     "eslint-config-next": "15.2.4",
     "next": "15.2.4",
     "postcss": "8.5.3",
-    "react": "18.3.1",
+    "react": "19.1.0",
     "react-dom": "19.1.0",
     "tailwindcss": "3.4.17",
     "typescript": "5.8.2"


### PR DESCRIPTION
fixes npm error While resolving: @types/react-dom@19.0.4
npm error Found: @types/react@18.3.12
npm error node_modules/@types/react
npm error   @types/react@"18.3.12" from the root project
npm error
npm error Could not resolve dependency:
npm error peer @types/react@"^19.0.0" from @types/react-dom@19.0.4
npm error node_modules/@types/react-dom
npm error   @types/react-dom@"19.0.4" from the root project
npm error
npm error Conflicting peer dependency: @types/react@19.0.12
npm error node_modules/@types/react
npm error   peer @types/react@"^19.0.0" from @types/react-dom@19.0.4
npm error   node_modules/@types/react-dom
npm error     @types/react-dom@"19.0.4" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.